### PR TITLE
Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ scripts/test/ipfs_data
 scripts/test/ipfs_staging
 scripts/test/neo4j_data
 scripts/test/neo4j_logs
-scripts/__pycache__/*
-scripts/databases/__pycache__/*
+__pycache__/

--- a/install.py
+++ b/install.py
@@ -25,8 +25,9 @@ SOFTWARE.
 """
 
 import launch
+import os
 
-with open('./extensions/stable-diffusion-database-manager/requirements.txt', 'r') as f:
+with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), 'r') as f:
     required_packages = [line.strip() for line in f.readlines() if line.strip()]
 
 for package in required_packages:

--- a/scripts/database_manager.py
+++ b/scripts/database_manager.py
@@ -26,50 +26,23 @@ SOFTWARE.
 
 import modules.scripts as scripts
 import gradio as gr
-import importlib
-import pkgutil
-import inspect
-import os
-import sys
+from scripts import nex_databases
+
+
 class DatabaseManagerNex(scripts.Script):
 
-    package_name = 'nex_databases'
-
-    databases = None
+    package_name = 'scripts.nex_databases'
 
     def __init__(self):
         super().__init__()
         self.databases = {}
-
-    def get_absolute_path(self, relative_path):
-        current_script_dir = os.path.dirname(__file__)
-        absolute_path = os.path.join(current_script_dir, relative_path)
-        return absolute_path
-    
-    def add_module_path(self, module_path):
-        module_dir = os.path.dirname(module_path)
-        if module_dir not in sys.path:
-            sys.path.insert(0, module_dir)
-
-    def import_module_from_path(self, relative_path):
-        absolute_path = self.get_absolute_path(relative_path)
-        self.add_module_path(absolute_path)
-        module_name = os.path.splitext(os.path.basename(absolute_path))[0]
-        module = importlib.import_module(module_name)
-        return module
+        self.databases_1 = {}
 
     def initialise_database_names(self):
 
-        package = self.import_module_from_path(self.package_name)
-        for _, module_name, _ in pkgutil.iter_modules(package.__path__):
-
-            module = importlib.import_module(f"{self.package_name}.{module_name}")
-
-            for _, obj in inspect.getmembers(module):
-                if inspect.isclass(obj) and obj.__module__ == module.__name__:
-                    class_instance = obj()
-                    self.databases[class_instance.name] = class_instance
-                    break
+        for database in nex_databases.all_database_classes:
+            class_instance = database()
+            self.databases[class_instance.name] = class_instance
 
     def selected_checkboxes(self, database_checkboxes_values):
         
@@ -81,7 +54,6 @@ class DatabaseManagerNex(scripts.Script):
                 ui_components_to_update.append(gr.update(visible=visibility))
 
         return ui_components_to_update
-
 
     def title(self):
         return "Database Manager Nex"

--- a/scripts/database_manager.py
+++ b/scripts/database_manager.py
@@ -31,8 +31,6 @@ from scripts import nex_databases
 
 class DatabaseManagerNex(scripts.Script):
 
-    package_name = 'scripts.nex_databases'
-
     def __init__(self):
         super().__init__()
         self.databases = {}
@@ -83,7 +81,6 @@ class DatabaseManagerNex(scripts.Script):
         return database_ui_components
 
     def postprocess(self, p, processed, *args):
-
 
         selected_databases_from_checkboxes = args[-1]
         grouped_database_values = {}

--- a/scripts/nex_databases/__init__.py
+++ b/scripts/nex_databases/__init__.py
@@ -1,0 +1,14 @@
+from .mongodb_database import MongoDBDatabase
+from .sqlite_database import SQLiteDatabase
+from .neo4j_database import Neo4jDatabase
+from .mysql_database import MySQLDatabase
+from .postgres_database import PostgresDatabase
+
+
+all_database_classes = [
+    MongoDBDatabase,
+    MySQLDatabase,
+    Neo4jDatabase,
+    PostgresDatabase,
+    SQLiteDatabase,
+]

--- a/scripts/nex_databases/mongodb_database.py
+++ b/scripts/nex_databases/mongodb_database.py
@@ -28,10 +28,11 @@ import gradio as gr
 from pymongo import MongoClient
 from io import BytesIO
 import logging
+from modules import generation_parameters_copypaste
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-from modules import generation_parameters_copypaste
+
 
 class MongoDBDatabase:
 
@@ -40,14 +41,14 @@ class MongoDBDatabase:
     database = None
     components = None
 
-    header = gr.Label(label=name, value=name, visible=False)
-    connection_string = gr.Textbox(label="Connection String", visible=False, placeholder="mongodb://root:your_password@localhost:27017/")
-    database_name = gr.Textbox(label="Database Name", visible=False, placeholder="Provide the name of the database")
-    collection_name = gr.Textbox(label="Collection Name", visible=False, placeholder="Provide the name of the collection")
-    connection_result_textarea = gr.TextArea(interactive=False, label='Connection Result', visible=False)
-    test_button = gr.Button(value="Test Connection", visible=False)
-
     def __init__(self):
+        self.header = gr.Label(label=self.name, value=self.name, visible=False)
+        self.connection_string = gr.Textbox(label="Connection String", visible=False, placeholder="mongodb://root:your_password@localhost:27017/")
+        self.database_name = gr.Textbox(label="Database Name", visible=False, placeholder="Provide the name of the database")
+        self.collection_name = gr.Textbox(label="Collection Name", visible=False, placeholder="Provide the name of the collection")
+        self.connection_result_textarea = gr.TextArea(interactive=False, label='Connection Result', visible=False)
+        self.test_button = gr.Button(value="Test Connection", visible=False)
+
         self.bind_event_handlers()
         self.components = [
             self.header,

--- a/scripts/nex_databases/mysql_database.py
+++ b/scripts/nex_databases/mysql_database.py
@@ -123,7 +123,7 @@ class MySQLDatabase:
                 logger.error(f"Error inserting data: {e}")
                 raise e
             finally:
-                 self.session_instance.close()
+                self.session_instance.close()
 
     def close(self):
         if self.connection:

--- a/scripts/nex_databases/mysql_database.py
+++ b/scripts/nex_databases/mysql_database.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 Base = declarative_base()
 
+
 class MySQLDatabase:
 
     name = "MySQL"
@@ -45,15 +46,15 @@ class MySQLDatabase:
     session_instance = None
     components = None
 
-    header = gr.Label(label=name, value=name, visible=False)
-    connection_string = gr.Textbox(label="Connection String", visible=False, placeholder="mysql+mysqlconnector://root:your_password@localhost:3306/your_database_name")
-    table_name = gr.Textbox(label="Table Name", visible=False, placeholder="Provide the name of the table")
-    image_metadata_column = gr.Textbox(label="Image Metadata Column Name", visible=False, placeholder="Provide the name of the column that stores the image metadata details")
-    image_bytes_column = gr.Textbox(label="Image Bytes Column Name", visible=False, placeholder="Provide the name of the column that stores the image")
-    connection_result_textarea = gr.TextArea(interactive=False, label='Connection Result', visible=False)
-    test_button = gr.Button(value="Test Connection", visible=False)
-
     def __init__(self):
+        self.header = gr.Label(label=self.name, value=self.name, visible=False)
+        self.connection_string = gr.Textbox(label="Connection String", visible=False, placeholder="mysql+mysqlconnector://root:your_password@localhost:3306/your_database_name")
+        self.table_name = gr.Textbox(label="Table Name", visible=False, placeholder="Provide the name of the table")
+        self.image_metadata_column = gr.Textbox(label="Image Metadata Column Name", visible=False, placeholder="Provide the name of the column that stores the image metadata details")
+        self.image_bytes_column = gr.Textbox(label="Image Bytes Column Name", visible=False, placeholder="Provide the name of the column that stores the image")
+        self.connection_result_textarea = gr.TextArea(interactive=False, label='Connection Result', visible=False)
+        self.test_button = gr.Button(value="Test Connection", visible=False)
+
         self.bind_event_handlers()
         self.components = [
             self.header,

--- a/scripts/nex_databases/neo4j_database.py
+++ b/scripts/nex_databases/neo4j_database.py
@@ -31,10 +31,11 @@ import logging
 from neo4j import GraphDatabase
 import ipfshttpclient
 import tempfile
+from modules import generation_parameters_copypaste
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-from modules import generation_parameters_copypaste
+
 
 class Neo4jDatabase:
 
@@ -43,14 +44,14 @@ class Neo4jDatabase:
     session_instance = None
     components = None
 
-    header = gr.Label(label=name, value=name, visible=False)
-    connection_string = gr.Textbox(label="Connection String", visible=False, placeholder="bolt://localhost:7687")
-    user_name = gr.Textbox(label="Username", visible=False, placeholder="neo4j")
-    password = gr.Textbox(label="Password", visible=False, placeholder="Provide your password", type="password")
-    connection_result_textarea = gr.TextArea(interactive=False, label='Connection Result', visible=False)
-    test_button = gr.Button(value="Test Connection", visible=False)
-
     def __init__(self):
+        self.header = gr.Label(label=self.name, value=self.name, visible=False)
+        self.connection_string = gr.Textbox(label="Connection String", visible=False, placeholder="bolt://localhost:7687")
+        self.user_name = gr.Textbox(label="Username", visible=False, placeholder="neo4j")
+        self.password = gr.Textbox(label="Password", visible=False, placeholder="Provide your password", type="password")
+        self.connection_result_textarea = gr.TextArea(interactive=False, label='Connection Result', visible=False)
+        self.test_button = gr.Button(value="Test Connection", visible=False)
+
         self.bind_event_handlers()
         self.components = [
             self.header,
@@ -81,7 +82,7 @@ class Neo4jDatabase:
             return message
 
     def insert(self, processed, input_values):
-        
+
         connection_string, user, password = input_values[1:4]
         self.instance(connection_string, user, password)
 
@@ -92,10 +93,10 @@ class Neo4jDatabase:
                     metadata = json.dumps(generation_parameters_copypaste.parse_generation_parameters(processed.infotexts[i]))
 
                     image = processed.images[i]
-                    
+
                     temp_file = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
                     image.save(temp_file, 'PNG')
-                    
+
                     response = client.add(temp_file.name)
                     ipfs_hash = response['Hash']
 
@@ -105,7 +106,7 @@ class Neo4jDatabase:
                     MERGE (p)-[:RELATED_TO]->(image)
                     RETURN image
                     """
-                    
+
                     self.session_instance.run(
                         cypher_query,
                         prompt_content=processed.prompt,

--- a/scripts/nex_databases/neo4j_database.py
+++ b/scripts/nex_databases/neo4j_database.py
@@ -121,7 +121,6 @@ class Neo4jDatabase:
             temp_file.close()
             os.remove(temp_file.name)
 
-
     def close(self):
         if self.session_instance:
             self.session_instance.close()

--- a/scripts/nex_databases/postgres_database.py
+++ b/scripts/nex_databases/postgres_database.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 Base = declarative_base()
 
+
 class PostgresDatabase:
 
     name = "PostgreSQL"
@@ -45,15 +46,15 @@ class PostgresDatabase:
     session_instance = None
     components = None
 
-    header = gr.Label(label=name, value=name, visible=False)
-    connection_string = gr.Textbox(label="Connection String", visible=False, placeholder="postgresql://postgres:your_password@localhost:5432/your_database_name")
-    table_name = gr.Textbox(label="Table Name", visible=False, placeholder="Provide the name of the table")
-    image_metadata_column = gr.Textbox(label="Image Metadata Column Name", visible=False, placeholder="Provide the name of the column that stores the image metadata details")
-    image_bytes_column = gr.Textbox(label="Image Bytes Column Name", visible=False, placeholder="Provide the name of the column that stores the image")
-    connection_result_textarea = gr.TextArea(interactive=False, label='Connection Result', visible=False)
-    test_button = gr.Button(value="Test Connection", visible=False)
-
     def __init__(self):
+        self.header = gr.Label(label=self.name, value=self.name, visible=False)
+        self.connection_string = gr.Textbox(label="Connection String", visible=False, placeholder="postgresql://postgres:your_password@localhost:5432/your_database_name")
+        self.table_name = gr.Textbox(label="Table Name", visible=False, placeholder="Provide the name of the table")
+        self.image_metadata_column = gr.Textbox(label="Image Metadata Column Name", visible=False, placeholder="Provide the name of the column that stores the image metadata details")
+        self.image_bytes_column = gr.Textbox(label="Image Bytes Column Name", visible=False, placeholder="Provide the name of the column that stores the image")
+        self.connection_result_textarea = gr.TextArea(interactive=False, label='Connection Result', visible=False)
+        self.test_button = gr.Button(value="Test Connection", visible=False)
+
         self.bind_event_handlers()
         self.components = [
             self.header,

--- a/scripts/nex_databases/sqlite_database.py
+++ b/scripts/nex_databases/sqlite_database.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 Base = declarative_base()
 
+
 class SQLiteDatabase:
 
     name = "SQLite"
@@ -45,15 +46,15 @@ class SQLiteDatabase:
     session_instance = None
     components = None
 
-    header = gr.Label(label=name, value=name, visible=False)
-    connection_string = gr.Textbox(label="Connection String", visible=False, placeholder="sqlite:///your_database_file.db")
-    table_name = gr.Textbox(label="Table Name", visible=False, placeholder="Provide the name of the table")
-    image_metadata_column = gr.Textbox(label="Image Metadata Column Name", visible=False, placeholder="Provide the name of the column that stores the image metadata details")
-    image_bytes_column = gr.Textbox(label="Image Bytes Column Name", visible=False, placeholder="Provide the name of the column that stores the image")
-    connection_result_textarea = gr.TextArea(interactive=False, label='Connection Result', visible=False)
-    test_button = gr.Button(value="Test Connection", visible=False)
-
     def __init__(self):
+        self.header = gr.Label(label=self.name, value=self.name, visible=False)
+        self.connection_string = gr.Textbox(label="Connection String", visible=False, placeholder="sqlite:///your_database_file.db")
+        self.table_name = gr.Textbox(label="Table Name", visible=False, placeholder="Provide the name of the table")
+        self.image_metadata_column = gr.Textbox(label="Image Metadata Column Name", visible=False, placeholder="Provide the name of the column that stores the image metadata details")
+        self.image_bytes_column = gr.Textbox(label="Image Bytes Column Name", visible=False, placeholder="Provide the name of the column that stores the image")
+        self.connection_result_textarea = gr.TextArea(interactive=False, label='Connection Result', visible=False)
+        self.test_button = gr.Button(value="Test Connection", visible=False)
+
         self.bind_event_handlers()
         self.components = [
             self.header,

--- a/scripts/nex_databases/sqlite_database.py
+++ b/scripts/nex_databases/sqlite_database.py
@@ -123,7 +123,7 @@ class SQLiteDatabase:
                 logger.error(f"Error inserting data: {e}")
                 raise e
             finally:
-                 self.session_instance.close()
+                self.session_instance.close()
 
     def close(self):
         if self.connection:


### PR DESCRIPTION
1. you're not using the correct path for your requirements.txt
2. all your database modules are creating gradio components in on class level which is an issue that you cleverly avoided by not importing the modules at the top of the main script<br>but what you did not realize is that this makes your UI entirely broken anywhere else apart from the first tab which is by default txt2img<br>your extension don't function when it's on img2img<br>a gradio component that can only be used once you can't reuse it (at least not like this)
3. I simplify the entire importing of the database modules

to be honest I don't know why you don't implement this in settings
maybe your use case is different but it looks like to me this is more of a set it and forget it type thing

---

not fixed

I did a quick test to confirm if all of the database modules works
apart from `MySQL` produce an ever like this
```
ERROR:scripts.nex_databases.mysql_database:Error obtaining the table: 'NoneType' object has no attribute 'replace'
```
all others did not produce an error

I only confirmed if the information is written to `sqlite`
I assume that they are probably written to the other databases apart from `MySQL`